### PR TITLE
Postfix dereferenciation

### DIFF
--- a/src/l0/ast/ast_printer.cpp
+++ b/src/l0/ast/ast_printer.cpp
@@ -151,9 +151,18 @@ void AstPrinter::Visit(const Assignment& assignment)
 
 void AstPrinter::Visit(const UnaryOp& unary_op)
 {
-    out_ << "(" << str(unary_op.op);
-    unary_op.operand->Accept(*this);
-    out_ << ")";
+    if (unary_op.op != UnaryOp::Operator::Caret)
+    {
+        out_ << "(" << str(unary_op.op);
+        unary_op.operand->Accept(*this);
+        out_ << ")";
+    }
+    else
+    {
+        out_ << "(";
+        unary_op.operand->Accept(*this);
+        out_ << str(unary_op.op) << ")";
+    }
 }
 
 void AstPrinter::Visit(const BinaryOp& binary_op)
@@ -367,8 +376,8 @@ std::string str(UnaryOp::Operator op)
             return "!";
         case UnaryOp::Operator::Ampersand:
             return "&";
-        case UnaryOp::Operator::Asterisk:
-            return "*";
+        case UnaryOp::Operator::Caret:
+            return "^";
     }
 }
 

--- a/src/l0/ast/expression.h
+++ b/src/l0/ast/expression.h
@@ -44,7 +44,7 @@ class UnaryOp : public Expression
         Minus,
         Bang,
         Ampersand,
-        Asterisk,
+        Caret,
     };
 
     UnaryOp(std::shared_ptr<Expression> operand, Operator op);

--- a/src/l0/generation/generator.cpp
+++ b/src/l0/generation/generator.cpp
@@ -382,7 +382,7 @@ void Generator::Visit(const UnaryOp& unary_op)
             GenerateResultAddress();
             break;
         }
-        case l0::UnaryOp::Operator::Asterisk:
+        case l0::UnaryOp::Operator::Caret:
         {
             unary_op.operand->Accept(*this);
             auto address = result_;

--- a/src/l0/lexing/lexer.cpp
+++ b/src/l0/lexing/lexer.cpp
@@ -40,24 +40,13 @@ Lexer::Lexer(std::shared_ptr<std::istream> input)
       }
 {
     single_character_operators_ = {
-        {'(', TokenType::OpeningParen},
-        {')', TokenType::ClosingParen},
-        {'[', TokenType::OpeningBracket},
-        {']', TokenType::ClosingBracket},
-        {'{', TokenType::OpeningBrace},
-        {'}', TokenType::ClosingBrace},
-        {'+', TokenType::Plus},
-        {'-', TokenType::Minus},
-        {'*', TokenType::Asterisk},
-        {'/', TokenType::Slash},
-        {'!', TokenType::Bang},
-        {'.', TokenType::Dot},
-        {',', TokenType::Comma},
-        {':', TokenType::Colon},
-        {';', TokenType::Semicolon},
-        {'=', TokenType::Equals},
-        {'$', TokenType::Dollar},
-        {'&', TokenType::Ampersand},
+        {'(', TokenType::OpeningParen},   {')', TokenType::ClosingParen}, {'[', TokenType::OpeningBracket},
+        {']', TokenType::ClosingBracket}, {'{', TokenType::OpeningBrace}, {'}', TokenType::ClosingBrace},
+        {'+', TokenType::Plus},           {'-', TokenType::Minus},        {'*', TokenType::Asterisk},
+        {'/', TokenType::Slash},          {'!', TokenType::Bang},         {'.', TokenType::Dot},
+        {',', TokenType::Comma},          {':', TokenType::Colon},        {';', TokenType::Semicolon},
+        {'=', TokenType::Equals},         {'$', TokenType::Dollar},       {'&', TokenType::Ampersand},
+        {'^', TokenType::Caret},
     };
 
     two_character_operators_ = {

--- a/src/l0/lexing/token.cpp
+++ b/src/l0/lexing/token.cpp
@@ -31,6 +31,8 @@ std::string str(TokenType type)
             return "Bang";
         case TokenType::Ampersand:
             return "Ampersand";
+        case TokenType::Caret:
+            return "Caret";
         case TokenType::EqualsEquals:
             return "EqualsEquals";
         case TokenType::BangEquals:

--- a/src/l0/lexing/token.h
+++ b/src/l0/lexing/token.h
@@ -26,6 +26,7 @@ enum class TokenType
     Slash,
     Bang,
     Ampersand,
+    Caret,
     EqualsEquals,
     BangEquals,
     AmpersandAmpersand,

--- a/src/l0/parsing/parser.cpp
+++ b/src/l0/parsing/parser.cpp
@@ -399,12 +399,6 @@ std::shared_ptr<Expression> Parser::ParseUnary()
             auto expression = ParseUnary();
             return std::make_shared<UnaryOp>(expression, UnaryOp::Operator::Ampersand);
         }
-        case TokenType::Asterisk:
-        {
-            Consume();
-            auto expression = ParseUnary();
-            return std::make_shared<UnaryOp>(expression, UnaryOp::Operator::Asterisk);
-        }
         default:
         {
             return ParseFactor();
@@ -418,10 +412,10 @@ std::shared_ptr<Expression> Parser::ParseFactor()
     {
         return ParseAllocation();
     }
-    return ParseCallsAndMemberAccessors();
+    return ParseCallsDerefsAndMemberAccessors();
 }
 
-std::shared_ptr<Expression> Parser::ParseCallsAndMemberAccessors()
+std::shared_ptr<Expression> Parser::ParseCallsDerefsAndMemberAccessors()
 {
     auto expression = ParseAtomicExpression();
 
@@ -436,6 +430,10 @@ std::shared_ptr<Expression> Parser::ParseCallsAndMemberAccessors()
         {
             auto member = Expect(TokenType::Identifier);
             expression = std::make_shared<MemberAccessor>(expression, std::any_cast<std::string>(member.data));
+        }
+        else if (ConsumeIf(TokenType::Caret))
+        {
+            expression = std::make_shared<UnaryOp>(expression, UnaryOp::Operator::Caret);
         }
         else
         {

--- a/src/l0/parsing/parser.h
+++ b/src/l0/parsing/parser.h
@@ -62,7 +62,7 @@ class Parser : public IParser
     std::shared_ptr<Expression> ParseTerm();
     std::shared_ptr<Expression> ParseUnary();
     std::shared_ptr<Expression> ParseFactor();
-    std::shared_ptr<Expression> ParseCallsAndMemberAccessors();
+    std::shared_ptr<Expression> ParseCallsDerefsAndMemberAccessors();
     std::shared_ptr<Expression> ParseAtomicExpression();
     std::shared_ptr<Expression> ParseFunction();
     std::shared_ptr<Expression> ParseInitializer();

--- a/src/l0/semantics/operator_overload_resolver.cpp
+++ b/src/l0/semantics/operator_overload_resolver.cpp
@@ -39,7 +39,7 @@ std::shared_ptr<Type> OperatorOverloadResolver::ResolveUnaryOperator(
     {
         return std::make_shared<ReferenceType>(operand, TypeQualifier::Constant);
     }
-    if (op == UnaryOp::Operator::Asterisk)
+    if (op == UnaryOp::Operator::Caret)
     {
         if (auto reference_type = dynamic_pointer_cast<ReferenceType>(operand))
         {

--- a/src/l0/semantics/reference_pass.cpp
+++ b/src/l0/semantics/reference_pass.cpp
@@ -173,7 +173,7 @@ bool ReferencePass::IsLValue(std::shared_ptr<Expression> value) const
         return true;
     }
     else if (auto unary_op = dynamic_pointer_cast<UnaryOp>(value);
-             unary_op && (unary_op->op == UnaryOp::Operator::Asterisk))
+             unary_op && (unary_op->op == UnaryOp::Operator::Caret))
     {
         return true;
     }


### PR DESCRIPTION
Caret (`^`) is now used for dereferenciation instead of Asterisk (`*`)