### PR TITLE
Fix member function generation

### DIFF
--- a/src/l0/ast/expression.h
+++ b/src/l0/ast/expression.h
@@ -196,6 +196,7 @@ class Function : public Expression
     std::shared_ptr<StatementBlock> statements;
 
     mutable std::shared_ptr<Scope> locals = std::make_shared<Scope>();
+    mutable std::optional<std::string> global_name{};
 };
 
 struct MemberInitializer

--- a/src/l0/semantics/global_scope_builder.cpp
+++ b/src/l0/semantics/global_scope_builder.cpp
@@ -1,5 +1,7 @@
 #include "l0/semantics/global_scope_builder.h"
 
+#include <format>
+
 #include "l0/ast/statement.h"
 #include "l0/ast/type_expression.h"
 #include "l0/semantics/semantic_error.h"
@@ -92,6 +94,11 @@ void GlobalScopeBuilder::FillTypeDetails(std::shared_ptr<TypeDeclaration> type_d
         else
         {
             member->type = type_resolver_.Convert(*member_declaration->annotation);
+        }
+
+        if (auto function = std::dynamic_pointer_cast<Function>(member->default_initializer))
+        {
+            function->global_name = std::format("__memberfct_{}::{}", struct_type->name, member->name);
         }
 
         struct_type->members->push_back(member);


### PR DESCRIPTION
Fixes a bug that makes programs crash once there are two instances of a struct with at least one member function.