### PR TITLE
Static members

### DIFF
--- a/src/l0/ast/expression.h
+++ b/src/l0/ast/expression.h
@@ -149,7 +149,7 @@ class MemberAccessor : public Expression
     std::string member;
 
     mutable std::shared_ptr<StructType> object_type;
-    mutable std::size_t member_index;
+    mutable std::optional<std::size_t> nonstatic_member_index;
 };
 
 using ArgumentList = std::vector<std::shared_ptr<Expression>>;

--- a/src/l0/semantics/global_scope_builder.cpp
+++ b/src/l0/semantics/global_scope_builder.cpp
@@ -93,6 +93,7 @@ void GlobalScopeBuilder::FillTypeDetails(std::shared_ptr<TypeDeclaration> type_d
         {
             member->type = type_resolver_.Convert(*method_annotation->function_type);
             member->is_method = true;
+            member->is_static = true;
         }
         else
         {

--- a/src/l0/semantics/reference_pass.cpp
+++ b/src/l0/semantics/reference_pass.cpp
@@ -175,11 +175,7 @@ bool ReferencePass::IsLValue(std::shared_ptr<Expression> value) const
     }
     else if (auto member_accessor = dynamic_pointer_cast<MemberAccessor>(value))
     {
-        if (IsLValue(member_accessor->object))
-        {
-            return true;
-        }
-        return false;
+        return member_accessor->nonstatic_member_index.has_value() && IsLValue(member_accessor->object);
     }
     return false;
 }

--- a/src/l0/types/types.h
+++ b/src/l0/types/types.h
@@ -133,6 +133,7 @@ class StructMember
     std::shared_ptr<Expression> default_initializer;
 
     bool is_method{false};
+    bool is_static{false};
 };
 
 using StructMemberList = std::vector<std::shared_ptr<StructMember>>;
@@ -151,7 +152,7 @@ class StructType : public Type
 
     bool HasMember(std::string name) const;
     std::shared_ptr<StructMember> GetMember(std::string name) const;
-    std::size_t GetMemberIndex(std::string name) const;
+    std::optional<std::size_t> GetNonstaticMemberIndex(std::string name) const;
 
    protected:
     bool Equals(const Type& other) const override;


### PR DESCRIPTION
Fix #75 

Static members are resolved at compile time, and thus do not take up any space in the object itself. As of now, the only static members are methods.

This change vastly reduces the memory usage und IR code length of examples/string.l0, since the String struct now only has three members, and method calls are resolved at compile time.