### PR TITLE
Add modules

### DIFF
--- a/examples/faculty.l0
+++ b/examples/faculty.l0
@@ -1,0 +1,21 @@
+fn main () -> I64
+{
+    while true:
+    {
+        line := read_ln();
+        n := string_to_i64(&line);
+        fac_n := fac(n);
+
+        s : mut = from_cstring("Faculty of ");
+        s.append_i64(n);
+        s.append_cstring(" is ");
+        s.append_i64(fac_n);
+        s.append_c8('\n');
+        print_string(&s);
+
+        line.free();
+        s.free();
+    };
+
+    return 0;
+};

--- a/examples/math.l0
+++ b/examples/math.l0
@@ -1,0 +1,32 @@
+fn fac (n : I64) -> I64
+{
+    if n == 0:
+    {
+        return 1;
+    };
+    return n * fac(n-1);
+};
+
+fn pow (a : I64, b : I64) -> I64
+{
+    result : mut = 1;
+    i : mut = 0;
+    while i < b:
+    {
+        result = result * a;
+        i = i + 1;
+    };
+    return result;
+};
+
+fn n_digits (n : I64) -> I64
+{
+    result : mut = 1;
+    remainder : mut = n;
+    while remainder >= 10:
+    {
+        result = result + 1;
+        remainder = remainder / 10;
+    };
+    return result;
+};

--- a/examples/print.l0
+++ b/examples/print.l0
@@ -1,0 +1,16 @@
+fn print_ln () -> ()
+{
+    printf("\n");
+};
+
+fn print_string (string : &String) -> ()
+{
+    printf(string^.cstring());
+};
+
+fn print_i64 (i64 : I64) -> ()
+{
+    s := from_i64(i64);
+    print_string(&s);
+    s.free();
+};

--- a/examples/read.l0
+++ b/examples/read.l0
@@ -1,0 +1,11 @@
+fn read_ln () -> String
+{
+    s : mut = String{};
+    c : mut = getchar();
+    while c != '\n':
+    {
+        s.append_c8(c);
+        c = getchar();
+    };
+    return s;
+};

--- a/examples/string.l0
+++ b/examples/string.l0
@@ -1,63 +1,3 @@
-fn main () -> I64
-{
-    while true:
-    {
-        line := read_ln();
-        n := string_to_i64(&line);
-        fac_n := fac(n);
-
-        s : mut = from_cstring("Faculty of ");
-        s.append_i64(n);
-        s.append_cstring(" is ");
-        s.append_i64(fac_n);
-        s.append_c8('\n');
-        print_string(&s);
-
-        line.free();
-        s.free();
-    };
-
-    return 0;
-};
-
-fn print_ln () -> ()
-{
-    printf("\n");
-};
-
-fn print_string (string : &String) -> ()
-{
-    printf(string^.cstring());
-};
-
-fn print_i64 (i64 : I64) -> ()
-{
-    s := from_i64(i64);
-    print_string(&s);
-    s.free();
-};
-
-fn read_ln () -> String
-{
-    s : mut = String{};
-    c : mut = getchar();
-    while c != '\n':
-    {
-        s.append_c8(c);
-        c = getchar();
-    };
-    return s;
-};
-
-fn fac (n : I64) -> I64
-{
-    if n == 0:
-    {
-        return 1;
-    };
-    return n * fac(n-1);
-};
-
 fn cstring_len (cstring : CString) -> I64
 {
     length : mut = 0;
@@ -144,30 +84,6 @@ fn c8_to_digit (c8 : C8) -> I64
     else if c8 == '8': { return 8; }
     else if c8 == '9': { return 9; }
     else: { return -1; };
-};
-
-fn pow (a : I64, b : I64) -> I64
-{
-    result : mut = 1;
-    i : mut = 0;
-    while i < b:
-    {
-        result = result * a;
-        i = i + 1;
-    };
-    return result;
-};
-
-fn n_digits (n : I64) -> I64
-{
-    result : mut = 1;
-    remainder : mut = n;
-    while remainder >= 10:
-    {
-        result = result + 1;
-        remainder = remainder / 10;
-    };
-    return result;
 };
 
 struct String

--- a/src/l0/ast/module.h
+++ b/src/l0/ast/module.h
@@ -1,6 +1,7 @@
 #ifndef L0_AST_MODULE_H
 #define L0_AST_MODULE_H
 
+#include <filesystem>
 #include <memory>
 
 #include "l0/ast/expression.h"
@@ -14,13 +15,16 @@ class Module
 {
    public:
     std::shared_ptr<StatementBlock> statements{};
-    std::string name{};
+
+    std::string name;
+    std::filesystem::path source_path;
 
     std::shared_ptr<Scope> globals = std::make_shared<Scope>();
     std::shared_ptr<Scope> externals = std::make_shared<Scope>();
 
     std::vector<std::shared_ptr<Function>> callables{};
     std::vector<std::shared_ptr<Declaration>> global_declarations{};
+    std::vector<std::shared_ptr<TypeDeclaration>> global_type_declarations{};
 };
 
 }  // namespace l0

--- a/src/l0/ast/scope.cpp
+++ b/src/l0/ast/scope.cpp
@@ -151,6 +151,23 @@ const std::unordered_set<std::string>& Scope::GetTypes() const
     return types_;
 }
 
+void Scope::UpdateTypes(const Scope& other)
+{
+    for (const auto& [name, definition] : other.type_definitions_)
+    {
+        DeclareType(name);
+        DefineType(name, definition);
+    }
+}
+
+void Scope::UpdateVariables(const Scope& other)
+{
+    for (const auto& [name, type] : other.variable_types_)
+    {
+        DeclareVariable(name, type);
+    }
+}
+
 ScopeError::ScopeError(const std::string& message)
     : message_{message}
 {

--- a/src/l0/ast/scope.h
+++ b/src/l0/ast/scope.h
@@ -36,6 +36,9 @@ class Scope
     const std::unordered_set<std::string>& GetVariables() const;
     const std::unordered_set<std::string>& GetTypes() const;
 
+    void UpdateTypes(const Scope& other);
+    void UpdateVariables(const Scope& other);
+
    private:
     std::unordered_set<std::string> variables_;
     std::unordered_map<std::string, std::shared_ptr<Type>> variable_types_;

--- a/src/l0/generation/generator.h
+++ b/src/l0/generation/generator.h
@@ -19,14 +19,14 @@ namespace l0
 class Generator : private IConstExpressionVisitor, IConstStatementVisitor
 {
    public:
-    Generator(Module& module);
+    Generator(llvm::LLVMContext& context, Module& module);
 
     std::string Generate();
 
    private:
     Module& ast_module_;
 
-    llvm::LLVMContext context_{};
+    llvm::LLVMContext& context_;
     llvm::IRBuilder<> builder_;
     llvm::Module llvm_module_;
     llvm::DataLayout data_layout_{&llvm_module_};
@@ -36,9 +36,9 @@ class Generator : private IConstExpressionVisitor, IConstStatementVisitor
     llvm::Value* result_address_;
     llvm::Value* object_ptr_;
 
-    void DeclareExternals();
-    void DeclareGlobalTypes();
-    void FillGlobalTypes();
+    void DeclareExternalVariables();
+    void DeclareTypes();
+    void FillTypes();
     void DeclareCallables();
     void DeclareCallable(std::shared_ptr<Function> function);
     void DefineCallables();

--- a/src/l0/lexing/lexer.cpp
+++ b/src/l0/lexing/lexer.cpp
@@ -22,7 +22,7 @@ bool IsValidIdentifierCharacter(char c)
 
 }  // namespace
 
-Lexer::Lexer(std::shared_ptr<std::istream> input)
+Lexer::Lexer(std::istream& input)
     : input_{input},
       keywords_{
           Keyword::Constant,
@@ -117,25 +117,25 @@ std::vector<Token> Lexer::GetTokens()
 
 bool Lexer::AtEnd() const
 {
-    return input_->eof();
+    return input_.eof();
 }
 
 char Lexer::Read()
 {
-    return current_ = input_->get();
+    return current_ = input_.get();
 }
 
 char Lexer::Skip()
 {
     while (current_ == ' ' || current_ == '\n')
     {
-        current_ = input_->get();
+        current_ = input_.get();
     }
     if (current_ == '#')
     {
         while (current_ != '\n')
         {
-            current_ = input_->get();
+            current_ = input_.get();
         }
         return Skip();
     }

--- a/src/l0/lexing/lexer.h
+++ b/src/l0/lexing/lexer.h
@@ -22,7 +22,7 @@ class ILexer
 class Lexer : public ILexer
 {
    public:
-    Lexer(std::shared_ptr<std::istream> input);
+    Lexer(std::istream& input);
     std::vector<Token> GetTokens();
 
    private:
@@ -39,7 +39,7 @@ class Lexer : public ILexer
     Token ReadStringLiteral();
 
     char current_{};
-    std::shared_ptr<std::istream> input_;
+    std::istream& input_;
 
     std::unordered_map<char, TokenType> single_character_operators_;
     std::unordered_map<std::string, TokenType> two_character_operators_;

--- a/src/l0/main/main.cpp
+++ b/src/l0/main/main.cpp
@@ -1,10 +1,15 @@
 #include <filesystem>
 #include <fstream>
-#include <iostream>
 #include <memory>
 #include <print>
+#include <ranges>
+//
+// #include "l0/ast/ast_printer.h"
 
-#include "l0/ast/ast_printer.h"
+#include <llvm/IR/LLVMContext.h>
+
+#include "l0/ast/module.h"
+#include "l0/common/constants.h"
 #include "l0/generation/generator.h"
 #include "l0/generation/generator_error.h"
 #include "l0/lexing/lexer.h"
@@ -14,20 +19,97 @@
 #include "l0/semantics/resolver.h"
 #include "l0/semantics/return_statement_pass.h"
 #include "l0/semantics/semantic_error.h"
+#include "l0/semantics/top_level_analyzer.h"
 #include "l0/semantics/typechecker.h"
+
+namespace l0
+{
+
+namespace fs = std::filesystem;
+
+void DeclareExternals(l0::Module& module);
+
+std::shared_ptr<l0::Module> GetModule(const fs::path& input_path);
+
+void SemanticCheckModule(l0::Module& module);
+
+void GenerateIRForModule(l0::Module& module, llvm::LLVMContext& context, const fs::path& output_path);
+
+}  // namespace l0
 
 int main(int argc, char* argv[])
 {
-    using namespace ::l0;
-    namespace fs = ::std::filesystem;
+    using namespace l0;
+    namespace fs = std::filesystem;
 
     std::println("Hello, World!");
 
-    fs::path input_path{argv[1]};
+    std::vector<fs::path> input_paths{argv + 1, argv + argc};
 
-    auto input_file = std::make_shared<std::ifstream>(input_path);
+    std::println("Loading {} modules", input_paths.size());
 
-    std::println("Lexical analysis...");
+    auto modules = input_paths | std::views::transform(GetModule) | std::ranges::to<std::vector>();
+
+    std::println("Building global scope");
+    for (const auto& module : modules)
+    {
+        for (const auto& other_module : modules)
+        {
+            if (other_module->name != module->name)
+            {
+                module->externals->UpdateTypes(*other_module->globals);
+            }
+        }
+
+        try
+        {
+            GlobalScopeBuilder{*module}.Run();
+        }
+        catch (const SemanticError& err)
+        {
+            std::println("Semantic error occured: {}", err.GetMessage());
+            exit(-1);
+        }
+    }
+
+    std::println("Semantic analysis");
+    for (const auto& module : modules)
+    {
+        for (const auto& other_module : modules)
+        {
+            if (other_module->name != module->name)
+            {
+                module->externals->UpdateVariables(*other_module->globals);
+            }
+        }
+
+        SemanticCheckModule(*module);
+    }
+
+    llvm::LLVMContext context{};
+
+    std::println("Generating IR");
+    for (const auto& module : modules)
+    {
+        fs::path output_path{module->source_path};
+        output_path.replace_extension("ll");
+        GenerateIRForModule(*module, context, output_path);
+    }
+
+    std::println("Leaving.");
+}
+
+namespace l0
+{
+
+std::shared_ptr<l0::Module> GetModule(const fs::path& input_path)
+{
+    using namespace l0;
+
+    std::println("Loading source file '{}'", input_path.string());
+    std::ifstream input_file{input_path};
+
+    std::println("Lexical analysis");
     std::vector<Token> tokens;
     try
     {
@@ -36,10 +118,10 @@ int main(int argc, char* argv[])
     catch (const LexerError& le)
     {
         std::println("Lexer error occured: {}", le.GetMessage());
-        return -1;
+        exit(-1);
     }
 
-    std::println("Syntactical analysis...");
+    std::println("Syntactical analysis");
     std::shared_ptr<Module> module;
     try
     {
@@ -48,101 +130,130 @@ int main(int argc, char* argv[])
     catch (const ParserError& pe)
     {
         std::println("Parser error occured: {}", pe.GetMessage());
-        return -1;
+        exit(-1);
     }
 
-    std::println("Result:");
-    AstPrinter{std::cout}.Print(*module);
+    module->name = input_path.stem();
+    module->source_path = input_path;
 
-    module->name = "MainModule";
+    DeclareExternals(*module);
 
-    auto character_type = std::make_shared<CharacterType>(TypeQualifier::Constant);
-    auto parameters = std::make_shared<ParameterList>(std::initializer_list<std::shared_ptr<Type>>{
-        std::make_shared<ReferenceType>(character_type, TypeQualifier::Constant)
-    });
-    auto integer_type = std::make_shared<IntegerType>(TypeQualifier::Constant);
-    auto string_to_int = std::make_shared<FunctionType>(parameters, integer_type, TypeQualifier::Constant);
-    auto void_to_char = std::make_shared<FunctionType>(std::make_shared<ParameterList>(), character_type, TypeQualifier::Constant);
+    // std::println("Result:");
+    // AstPrinter{std::cout}.Print(*module);
 
-    module->externals->DeclareVariable("printf", string_to_int);
-    module->externals->DeclareVariable("getchar", void_to_char);
-
-    std::println("Semantical analysis...");
-
-    std::println("Building global scope...");
+    std::println("Analyzing top level statements");
     try
     {
-        GlobalScopeBuilder{*module}.Run();
+        TopLevelAnalyzer{*module}.Run();
     }
     catch (const SemanticError& err)
     {
         std::println("Semantic error occured: {}", err.GetMessage());
-        return -1;
+        exit(-1);
     }
 
-    std::println("Resolving variables...");
+    return module;
+}
+
+void DeclareExternals(l0::Module& module)
+{
+    using namespace l0;
+
+    module.externals->DeclareType(Typename::Unit);
+    module.externals->DeclareType(Typename::Boolean);
+    module.externals->DeclareType(Typename::Integer);
+    module.externals->DeclareType(Typename::Character);
+    module.externals->DeclareType(Typename::CString);
+
+    module.externals->DefineType(Typename::Unit, std::make_shared<UnitType>(TypeQualifier::Constant));
+    module.externals->DefineType(Typename::Boolean, std::make_shared<BooleanType>(TypeQualifier::Constant));
+    auto i64 = std::make_shared<IntegerType>(TypeQualifier::Constant);
+    module.externals->DefineType(Typename::Integer, i64);
+    auto c8 = std::make_shared<CharacterType>(TypeQualifier::Constant);
+    module.externals->DefineType(Typename::Character, c8);
+    auto cstring = std::make_shared<ReferenceType>(c8, TypeQualifier::Constant);
+    module.externals->DefineType(Typename::CString, cstring);
+
+    auto parameters_string = std::make_shared<ParameterList>(std::initializer_list<std::shared_ptr<Type>>{cstring});
+    auto string_to_int = std::make_shared<FunctionType>(parameters_string, i64, TypeQualifier::Constant);
+    module.externals->DeclareVariable("printf", string_to_int);
+
+    auto void_to_char = std::make_shared<FunctionType>(std::make_shared<ParameterList>(), c8, TypeQualifier::Constant);
+    module.externals->DeclareVariable("getchar", void_to_char);
+}
+
+void SemanticCheckModule(l0::Module& module)
+{
+    using namespace l0;
+
+    std::println("Checking module '{}'", module.name);
+
+    std::println("Resolving variables");
     try
     {
-        Resolver{*module}.Check();
+        Resolver{module}.Check();
     }
     catch (const SemanticError& err)
     {
         std::println("Semantic error occured: {}", err.GetMessage());
-        return -1;
+        exit(-1);
     }
 
-    std::println("Checking types...");
+    std::println("Checking types");
     try
     {
-        Typechecker{*module}.Check();
+        Typechecker{module}.Check();
     }
     catch (const SemanticError& err)
     {
         std::println("Semantic error occured: {}", err.GetMessage());
-        return -1;
+        exit(-1);
     }
 
-    std::println("Checking return statements...");
+    std::println("Checking return statements");
     try
     {
-        ReturnStatementPass{*module}.Run();
+        ReturnStatementPass{module}.Run();
     }
     catch (const SemanticError& err)
     {
         std::println("Semantic error occured: {}", err.GetMessage());
-        return -1;
+        exit(-1);
     }
 
-    std::println("Reference pass...");
+    std::println("Reference pass");
     try
     {
-        ReferencePass{*module}.Run();
+        ReferencePass{module}.Run();
     }
     catch (const SemanticError& err)
     {
         std::println("Semantic error occured: {}", err.GetMessage());
-        return -1;
+        exit(-1);
     }
+}
 
-    std::println("Compiling...");
+void GenerateIRForModule(l0::Module& module, llvm::LLVMContext& context, const fs::path& output_path)
+{
+    using namespace l0;
+
+    std::println("Generating IR for module '{}'", module.name);
     try
     {
-        std::string code = Generator{*module}.Generate();
-        fs::path output_path = input_path;
-        output_path.replace_extension("ll");
+        std::string code = Generator{context, module}.Generate();
         std::ofstream output_file{output_path};
         output_file << code;
     }
     catch (const GeneratorError& ge)
     {
         std::println("Generator error occured: {}", ge.GetMessage());
-        return -1;
+        exit(-1);
     }
     catch (const ScopeError& se)
     {
         std::println("Scope error occured: {}", se.GetMessage());
-        return -1;
+        exit(-1);
     }
-
-    std::println("Leaving.");
 }
+
+}  // namespace l0

--- a/src/l0/semantics/CMakeLists.txt
+++ b/src/l0/semantics/CMakeLists.txt
@@ -14,6 +14,8 @@ add_library(
   return_statement_pass.h
   semantic_error.cpp
   semantic_error.h
+  top_level_analyzer.cpp
+  top_level_analyzer.h
   type_resolver.cpp
   type_resolver.h
   typechecker.cpp

--- a/src/l0/semantics/global_scope_builder.h
+++ b/src/l0/semantics/global_scope_builder.h
@@ -1,6 +1,8 @@
 #ifndef L0_SEMANTICS_GLOBAL_SCOPE_BUILDER_H
 #define L0_SEMANTICS_GLOBAL_SCOPE_BUILDER_H
 
+#include <memory>
+
 #include "l0/ast/module.h"
 #include "l0/semantics/type_resolver.h"
 
@@ -15,7 +17,6 @@ class GlobalScopeBuilder
     void Run();
 
    private:
-    void DeclareType(std::shared_ptr<TypeDeclaration> type_declaration);
     void FillTypeDetails(std::shared_ptr<TypeDeclaration> type_declaration);
     void DeclareVariable(std::shared_ptr<Declaration> declaration);
 

--- a/src/l0/semantics/top_level_analyzer.cpp
+++ b/src/l0/semantics/top_level_analyzer.cpp
@@ -1,0 +1,47 @@
+#include "l0/semantics/top_level_analyzer.h"
+
+#include "l0/semantics/semantic_error.h"
+
+namespace l0
+{
+
+TopLevelAnalyzer::TopLevelAnalyzer(Module& module)
+    : module_{module}
+{
+}
+
+void TopLevelAnalyzer::Run()
+{
+    for (auto& statement : module_.statements->statements)
+    {
+        if (auto declaration = dynamic_pointer_cast<Declaration>(statement))
+        {
+            module_.global_declarations.push_back(declaration);
+        }
+        else if (auto type_declaration = dynamic_pointer_cast<TypeDeclaration>(statement))
+        {
+            module_.global_type_declarations.push_back(type_declaration);
+        }
+        else
+        {
+            throw SemanticError("Only variable and type declarations are allowed as global statements.");
+        }
+    }
+
+    for (auto type_declaration : module_.global_type_declarations)
+    {
+        DeclareType(type_declaration);
+    }
+}
+
+void TopLevelAnalyzer::DeclareType(std::shared_ptr<TypeDeclaration> type_declaration)
+{
+    module_.globals->DeclareType(type_declaration->name);
+
+    auto type = std::make_shared<StructType>(
+        type_declaration->name, std::make_shared<StructMemberList>(), TypeQualifier::Constant
+    );
+    module_.globals->DefineType(type_declaration->name, type);
+}
+
+}  // namespace l0

--- a/src/l0/semantics/top_level_analyzer.h
+++ b/src/l0/semantics/top_level_analyzer.h
@@ -1,0 +1,26 @@
+#ifndef L0_SEMANTICS_TOP_LEVEL_ANALYZER
+#define L0_SEMANTICS_TOP_LEVEL_ANALYZER
+
+#include <memory>
+
+#include "l0/ast/module.h"
+
+namespace l0
+{
+
+class TopLevelAnalyzer
+{
+   public:
+    TopLevelAnalyzer(Module& module);
+
+    void Run();
+
+   private:
+    void DeclareType(std::shared_ptr<TypeDeclaration> type_declaration);
+
+    Module& module_;
+};
+
+}  // namespace l0
+
+#endif

--- a/src/l0/semantics/type_resolver.h
+++ b/src/l0/semantics/type_resolver.h
@@ -19,6 +19,7 @@ class TypeResolver : private ITypeAnnotationVisitor
     std::shared_ptr<Type> Convert(const TypeAnnotation& annotation);
     TypeQualifier Convert(TypeAnnotationQualifier qualifier);
     std::shared_ptr<FunctionType> Convert(const Function& function);
+    std::shared_ptr<Type> Resolve(std::string_view name);
 
    private:
     const Module& module_;

--- a/src/l0/semantics/typechecker.cpp
+++ b/src/l0/semantics/typechecker.cpp
@@ -78,7 +78,7 @@ void Typechecker::Visit(const ConditionalStatement& conditional_statement)
 {
     conditional_statement.condition->Accept(*this);
     if (!conversion_checker_.CheckCompatibility(
-            conditional_statement.condition->type, module_.globals->GetTypeDefinition(Typename::Boolean)
+            conditional_statement.condition->type, type_resolver_.Resolve(Typename::Boolean)
         ))
     {
         throw SemanticError(std::format(
@@ -97,9 +97,7 @@ void Typechecker::Visit(const ConditionalStatement& conditional_statement)
 void Typechecker::Visit(const WhileLoop& while_loop)
 {
     while_loop.condition->Accept(*this);
-    if (!conversion_checker_.CheckCompatibility(
-            while_loop.condition->type, module_.globals->GetTypeDefinition(Typename::Boolean)
-        ))
+    if (!conversion_checker_.CheckCompatibility(while_loop.condition->type, type_resolver_.Resolve(Typename::Boolean)))
     {
         throw SemanticError(std::format(
             "Condition must be of type Boolean, but is of type '{}'.", while_loop.condition->type->ToString()
@@ -222,27 +220,27 @@ void Typechecker::Visit(const Call& call)
 
 void Typechecker::Visit(const UnitLiteral& literal)
 {
-    literal.type = module_.globals->GetTypeDefinition(Typename::Unit);
+    literal.type = type_resolver_.Resolve(Typename::Unit);
 }
 
 void Typechecker::Visit(const BooleanLiteral& literal)
 {
-    literal.type = module_.globals->GetTypeDefinition(Typename::Boolean);
+    literal.type = type_resolver_.Resolve(Typename::Boolean);
 }
 
 void Typechecker::Visit(const IntegerLiteral& literal)
 {
-    literal.type = module_.globals->GetTypeDefinition(Typename::Integer);
+    literal.type = type_resolver_.Resolve(Typename::Integer);
 }
 
 void Typechecker::Visit(const CharacterLiteral& literal)
 {
-    literal.type = module_.globals->GetTypeDefinition(Typename::Character);
+    literal.type = type_resolver_.Resolve(Typename::Character);
 }
 
 void Typechecker::Visit(const StringLiteral& literal)
 {
-    literal.type = module_.globals->GetTypeDefinition(Typename::CString);
+    literal.type = type_resolver_.Resolve(Typename::CString);
 }
 
 void Typechecker::Visit(const Function& function)
@@ -329,7 +327,7 @@ void Typechecker::Visit(const Allocation& allocation)
     if (allocation.size)
     {
         allocation.size->Accept(*this);
-        auto integer_type = module_.globals->GetTypeDefinition("I64");
+        auto integer_type = type_resolver_.Resolve(Typename::Integer);
         if (*allocation.size->type != *integer_type)
         {
             throw SemanticError(std::format(


### PR DESCRIPTION
Fix #72 

Code can be spread out over several files by calling the compiler with all files as arguments. No explicit import statement etc. is required (similar to C#).