### PR TITLE
Enable manual deletion of closure context

### DIFF
--- a/examples/closures/closures.l0
+++ b/examples/closures/closures.l0
@@ -8,5 +8,11 @@ fn main () -> I64
 
     h := $ [f, g] (x : I64) -> I64 { return f(g(x)); };
 
-    return h(3);
+    result := h(3);
+
+    delete f;
+    delete g;
+    delete h;
+
+    return result;
 };

--- a/src/l0/ast/statement.h
+++ b/src/l0/ast/statement.h
@@ -123,12 +123,20 @@ class WhileLoop : public Statement
 class Deallocation : public Statement
 {
    public:
+    enum class DeallocationType
+    {
+        None,
+        Reference,
+        Closure,
+    };
+
     Deallocation(std::shared_ptr<Expression> reference);
 
     void Accept(IConstStatementVisitor& visitor) const override;
     void Accept(IStatementVisitor& visitor) override;
 
     std::shared_ptr<Expression> reference;
+    mutable DeallocationType deallocation_type{DeallocationType::None};
 };
 
 class IConstStatementVisitor

--- a/src/l0/semantics/typechecker.cpp
+++ b/src/l0/semantics/typechecker.cpp
@@ -112,11 +112,19 @@ void Typechecker::Visit(const WhileLoop& while_loop)
 void Typechecker::Visit(const Deallocation& deallocation)
 {
     deallocation.reference->Accept(*this);
-    auto reference_type = dynamic_pointer_cast<ReferenceType>(deallocation.reference->type);
-    if (!reference_type)
+
+    if (dynamic_pointer_cast<ReferenceType>(deallocation.reference->type))
+    {
+        deallocation.deallocation_type = Deallocation::DeallocationType::Reference;
+    }
+    else if (dynamic_pointer_cast<FunctionType>(deallocation.reference->type))
+    {
+        deallocation.deallocation_type = Deallocation::DeallocationType::Closure;
+    }
+    else
     {
         throw SemanticError(std::format(
-            "Operand of delete statement must be of reference type, but is of type '{}'.",
+            "Operand of delete statement must be of reference or function type, but is of type '{}'.",
             deallocation.reference->type->ToString()
         ));
     }


### PR DESCRIPTION
Enable `delete f;` for `f` of function type. It deletes the dynamically allocated function context. This is invalid when the closure in question has no capture list.