### PR TITLE
Change char8_t to char

### DIFF
--- a/src/l0/lexing/lexer.cpp
+++ b/src/l0/lexing/lexer.cpp
@@ -257,7 +257,7 @@ Token Lexer::ReadCharacterLiteral()
     }
     Read();
 
-    char8_t character = current_;
+    char character = current_;
     if (character == '\\')
     {
         Read();


### PR DESCRIPTION
An upgrade of glibc (?) seems to break `std::format` with `char8_t`