### PR TITLE
Bugfix/issue 109/fix if else printing

### DIFF
--- a/src/l0/ast/ast_printer.cpp
+++ b/src/l0/ast/ast_printer.cpp
@@ -114,7 +114,6 @@ void AstPrinter::Visit(const ConditionalStatement& conditional_statement)
 
     if (conditional_statement.else_block)
     {
-        return;
         out_ << "\n" << Keyword::Else << "\n";
         conditional_statement.else_block->Accept(*this);
     }

--- a/src/l0/lexing/lexer.cpp
+++ b/src/l0/lexing/lexer.cpp
@@ -274,7 +274,7 @@ Token Lexer::ReadCharacterLiteral()
     Skip();
     return Token{
         .type = TokenType::CharacterLiteral,
-        .lexeme = std::format("'{}'", character),
+        .lexeme = std::format("'{}'", (char)character),
         .data = character,
     };
 }


### PR DESCRIPTION
Fix #109 

Also fix a bug related to `std::format` and `char8_t`, apparently introduced by a glibc update (?)